### PR TITLE
Only escape underscores outside of equations

### DIFF
--- a/critdd/tests/tikz.py
+++ b/critdd/tests/tikz.py
@@ -3,5 +3,13 @@ from unittest import TestCase
 
 class TestTikz(TestCase):
   def test_tikz(self):
-    self.assertEqual(tikz._label("with_underscore"), "with\\_underscore")
-    self.assertEqual(tikz._label("with\\_underscore"), "with\\_underscore")
+    self.assertEqual(tikz._label("with_under_score"), "with\\_under\\_score")
+    self.assertEqual(tikz._label("with\\_under_score"), "with\\_under\\_score")
+    self.assertEqual(
+      tikz._label("with_equations $n_i$ and $m_j$"),
+      "with\\_equations $n_i$ and $m_j$"
+    )
+    self.assertEqual(
+      tikz._label("$\\mathrm{full}_\\text{equation}$"),
+      "$\\mathrm{full}_\\text{equation}$"
+    )

--- a/critdd/tikz.py
+++ b/critdd/tikz.py
@@ -180,6 +180,12 @@ def _axis(*contents, options=[]):
 def _treatment(label, rank, xpos, ypos, anchor, reverse_x):
     return f"\\draw[treatment line] ([yshift=-2pt] axis cs:{rank}, 0) |- (axis cs:{xpos}, {-ypos})\n  node[treatment label, anchor={anchor}] {{{_label(label)}}};"
 def _label(label):
-    return re.sub("(?<!\\\\)_", "\\\\_", label) # replace "_", but not "\_", with "\_"
+    parts = []
+    for i, part in enumerate(re.split("\$", label)): # split on equation boundaries
+        if i % 2 == 0: # if the current part is outside of an equation
+            parts.append(re.sub("(?<!\\\\)_", "\\\\_", part)) # { "_", "\_" } -> "\_"
+        else:
+            parts.append(part) # do not escape underscores inside of equations
+    return "$".join(parts) # combine parts with equation boundaries
 def _group(minrank, maxrank, ypos):
     return f"\\draw[group line] (axis cs:{minrank}, {-ypos}) -- (axis cs:{maxrank}, {-ypos});"


### PR DESCRIPTION
As discussed with @MatthiasJakobs in PR #6 underscores are now only escaped outside of equations.